### PR TITLE
[IMP] apriori.py: document modules that moved to a different repo

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -158,3 +158,24 @@ merged_models = {
     "gift.card": "loyalty.card",
     # OCA/...
 }
+
+# List of OCA modules that were moved to other repositories .
+# Format: {"module_name": ("old_repo_name", "new_repo_name")}
+# Note: The key is the module_name for easier reference
+moved_modules = {
+    # OCA/edi
+    "edi_account_oca": ("edi", "edi-framework"),
+    "edi_backend_partner_oca": ("edi", "edi-framework"),
+    "edi_endpoint_oca": ("edi", "edi-framework"),
+    "edi_exchange_template_oca": ("edi", "edi-framework"),
+    "edi_oca": ("edi", "edi-framework"),
+    "edi_party_data_oca": ("edi", "edi-framework"),
+    "edi_sale_oca": ("edi", "edi-framework"),
+    "edi_stock_oca": ("edi", "edi-framework"),
+    "edi_storage_oca": ("edi", "edi-framework"),
+    "edi_ubl_oca": ("edi", "edi-framework"),
+    "edi_webservice_oca": ("edi", "edi-framework"),
+    "edi_xml_oca": ("edi", "edi-framework"),
+    # OCA/sale-workflow
+    "sale_rental": ("sale-workflow", "vertical-rental"),
+}


### PR DESCRIPTION
This PR introduces a new dictionary, **moved_modules**, to the `apriori.py` script. Its purpose is to maintain a map of OCA modules that have been moved to different repositories as part of ongoing refactoring efforts across Odoo versions.

### Motivation
During the migration to v16, several modules were relocated to new or restructured repositories to improve organization and maintainability. For example:

- Some EDI modules have been moved from the `OCA/edi` repository to the `OCA/edi-framework` repository.

- The sale_rental module has been moved from the `OCA/sale-workflow` repository to the `OCA/vertical-rental` repository.

Since the repository paths have changed, migration scripts need a mechanism to locate the new module locations. This update introduces a centralized lookup map that enables the upgrade framework to accurately identify the correct source paths.

### Solution
The **moved_modules** dictionary stores the old and new repository for each affected module, using the format:
```
{"module_name": ("old_repo_name", "new_repo_name")}
```